### PR TITLE
Month number in demo file name.

### DIFF
--- a/code/server/sv_ccmds.c
+++ b/code/server/sv_ccmds.c
@@ -998,7 +998,7 @@ static void SV_NameServerDemo(char *filename, int length, const client_t *client
 		// file extension
 		Com_sprintf(
 			filename, length-1, "serverdemos/%.4d_%.2d_%.2d_%.2d-%.2d-%.2d_%s_%d.dm_%d",
-			time.tm_year+1900, time.tm_mon, time.tm_mday,
+			time.tm_year+1900, time.tm_mon+1, time.tm_mday,
 			time.tm_hour, time.tm_min, time.tm_sec,
 			playername,
 			Sys_Milliseconds(),


### PR DESCRIPTION
You need to add 1 to the month number because month number is from 0 to
12 and not from 1 to 12.
(http://www.cplusplus.com/reference/clibrary/ctime/tm/)
