### PR TITLE
New s_devlist command and various fixes.

### DIFF
--- a/code/client/snd_dma.c
+++ b/code/client/snd_dma.c
@@ -124,6 +124,16 @@ void S_Base_SoundInfo(void) {
 
 /*
 =================
+S_dmaHD_devlist
+=================
+*/
+void S_dmaHD_devlist(void)
+{
+	SNDDMAHD_DevList();
+}
+
+/*
+=================
 S_Base_SoundList
 =================
 */
@@ -1442,6 +1452,7 @@ void S_Base_Shutdown( void ) {
 	s_soundStarted = 0;
 
 	Cmd_RemoveCommand("s_info");
+	Cmd_RemoveCommand("s_devlist");
 }
 
 /*
@@ -1456,13 +1467,19 @@ qboolean S_Base_Init( soundInterface_t *si ) {
 		return qfalse;
 	}
 
+#ifndef NO_DMAHD
+	s_khz = Cvar_Get ("s_khz", "44", CVAR_ARCHIVE);
+#else
 	s_khz = Cvar_Get ("s_khz", "22", CVAR_ARCHIVE);
+#endif
 	s_mixahead = Cvar_Get ("s_mixahead", "0.2", CVAR_ARCHIVE);
 	s_mixPreStep = Cvar_Get ("s_mixPreStep", "0.05", CVAR_ARCHIVE);
 	s_show = Cvar_Get ("s_show", "0", CVAR_CHEAT);
 	s_testsound = Cvar_Get ("s_testsound", "0", CVAR_CHEAT);
 	s_dev = Cvar_Get ("s_dev", "", CVAR_ARCHIVE);
 
+	Cmd_AddCommand( "s_devlist", S_dmaHD_devlist );
+	
 	r = SNDDMA_Init();
 
 	if ( r ) {

--- a/code/client/snd_dmahd.c
+++ b/code/client/snd_dmahd.c
@@ -186,7 +186,7 @@ float g_voltable[256];
 #define SMPCLAMP(a) (((a) < -32768) ? -32768 : ((a) > 32767) ? 32767 : (a))
 #define VOLCLAMP(a) (((a) < 0) ? 0 : ((a) > 255) ? 255 : (a))
 
-void dmaHD_InitTables()
+void dmaHD_InitTables(void)
 {
 	if (!g_tablesinit)
 	{
@@ -471,7 +471,7 @@ qboolean dmaHD_LoadSound(sfx_t *sfx)
 	// Information
 	Com_DPrintf("^3Loading sound: ^7%s", sfx->soundName);
 	if (info.width == 1) 
-		Com_DPrintf(" [^28^3bit ^7-> ^216^3bit]", sfx->soundName);
+		Com_DPrintf(" [^28^3bit ^7-> ^216^3bit]");
 	if (info.rate != dma.speed) 
 		Com_DPrintf(" [^2%d^3Hz ^7-> ^2%d^3Hz]", info.rate, dma.speed);
 	Com_DPrintf("\n");
@@ -1200,7 +1200,7 @@ All sounds are on the same cycle, so any duplicates can just
 sum up the channel multipliers.
 ==================
 */
-void dmaHD_AddLoopSounds () 
+void dmaHD_AddLoopSounds (void) 
 {
 	int			i, time;
 	channel_t	*ch;
@@ -1351,10 +1351,11 @@ void dmaHD_Update_Mix(void)
 	// and start any new sounds
 	S_ScanChannelStarts();
 
-	if ((sane = thisTime - lastTime) < 1) sane = 1;
+	if ((sane = thisTime - lastTime) < 8) sane = 8; // ms since last mix (cap to 8ms @ 125fps)
+	op = (int)((float)(dma.speed * sane) * 0.001); // samples to mix based on last mix time
 	mixahead = (int)((float)dma.speed * s_mixahead->value);
-	op = (int)((float)(dma.speed * sane) * 0.01);
-	if (op < mixahead) mixahead = op;
+	
+	if (mixahead < op) mixahead = op;
 	
 	// mix ahead of current position
 	endtime = s_soundtime + mixahead;
@@ -1377,7 +1378,7 @@ void dmaHD_Update_Mix(void)
 dmaHD_Enabled
 ================
 */
-qboolean dmaHD_Enabled() 
+qboolean dmaHD_Enabled(void) 
 {
 	if (dmaHD_Enable == NULL)
 		dmaHD_Enable = Cvar_Get("dmaHD_enable", "1", CVAR_ARCHIVE);

--- a/code/client/snd_dmahd.h
+++ b/code/client/snd_dmahd.h
@@ -9,7 +9,7 @@
 #ifndef NO_DMAHD
 
 qboolean dmaHD_LoadSound(sfx_t *sfx);
-qboolean dmaHD_Enabled();
+qboolean dmaHD_Enabled(void);
 qboolean dmaHD_Init(soundInterface_t *si);
 
 #endif

--- a/code/client/snd_local.h
+++ b/code/client/snd_local.h
@@ -174,6 +174,7 @@ typedef struct
 
 // initializes cycling through a DMA buffer and returns information on it
 qboolean SNDDMA_Init(void);
+qboolean SNDDMAHD_DevList(void);
 
 // gets the current DMA position
 int		SNDDMA_GetDMAPos(void);

--- a/code/null/null_snddma.c
+++ b/code/null/null_snddma.c
@@ -25,6 +25,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "../client/client.h"
 
+qboolean SNDDMAHD_DevList(void)
+{
+	return qfalse;
+}
+
 qboolean SNDDMA_Init(void)
 {
 	return qfalse;

--- a/code/unix/linux_snd.c
+++ b/code/unix/linux_snd.c
@@ -73,6 +73,22 @@ void Snd_Memset (void* dest, const int val, const size_t count)
   }
 }
 
+/*
+===============
+SNDDMAHD_DevList
+===============
+*/
+qboolean SNDDMAHD_DevList(void)
+{
+	// Not implemented.
+	return qtrue;
+}
+
+/*
+===============
+SNDDMA_Init
+===============
+*/
 qboolean SNDDMA_Init(void)
 {
 	int rc;

--- a/code/unix/sdl_snd.c
+++ b/code/unix/sdl_snd.c
@@ -196,6 +196,17 @@ static void print_audiospec(const char *str, const SDL_AudioSpec *spec)
 
 /*
 ===============
+SNDDMAHD_DevList
+===============
+*/
+qboolean SNDDMAHD_DevList(void)
+{
+	// Not implemented.
+	return qtrue;
+}
+
+/*
+===============
 SNDDMA_Init
 ===============
 */


### PR DESCRIPTION
New s_devlist command to list sound output devices (windows)
Now calling freelibrary to avoid memory leaks (windows)
Tweaked dmaHD default CVAR values.
Tweaked dmaHD mixer time sampling.
Changed code to be more C compliant and to remove compiler warnings.
