### PR TITLE
Linux paste support (require xclip to be installed on system)

### DIFF
--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -1211,8 +1211,8 @@ char *Sys_GetClipboardData(void)
       Q_strncpyz(data, cliptext, sizeof(cliptext));
       strtok(data, "\n\r\b");
     }
+    pclose(fp);
   }
-  pclose(fp);
 
   return data;
 }


### PR DESCRIPTION
I added pasting support on Linux via the xclip utility.
