### PR TITLE
Fixes the 'badinfo' problem

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -1272,7 +1272,8 @@ void Info_RemoveKey( char *s, const char *key ) {
 
 		if (!strcmp (key, pkey) )
 		{
-			strcpy (start, s);	// remove this part
+			//strcpy is not safe for overlapping copies, use memmove
+			memmove(start, s, strlen(s) + 1);
 			return;
 		}
 
@@ -1327,7 +1328,8 @@ void Info_RemoveKey_Big( char *s, const char *key ) {
 
 		if (!strcmp (key, pkey) )
 		{
-			strcpy (start, s);	// remove this part
+			//strcpy is not safe for overlapping copies, use memmove
+			memmove(start, s, strlen(s) + 1);
 			return;
 		}
 


### PR DESCRIPTION
strcpy is not overlap-safe. Using strcpy in Info_RemoveKey randomly
causes mangled userinfo strings and behavior varies based on
environment. memmove should be used instead.
