### PR TITLE
Removed reference to qeradiant.com due to malware

### DIFF
--- a/README
+++ b/README
@@ -32,7 +32,7 @@ for further development. Some of the major features currently implemented are:
   * Many, many bug fixes
 
 The map editor and associated compiling tools are not included. We suggest you
-use a modern copy from http://www.qeradiant.com/.
+use a modern copy.
 
 The original id software readme that accompanied the Q3 source release has been
 renamed to id-readme.txt so as to prevent confusion. Please refer to the


### PR DESCRIPTION
qeradiant.com appears to have been hijacked. Upon visiting the site, I was presented malware.
