### PR TITLE
Fixed memory allocation for Linux and Mac pasting

### DIFF
--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -1216,10 +1216,10 @@ char *Sys_GetClipboardData(void)
   }
   #endif
   if (fp != NULL) {
-    cliptext = Z_Malloc(1024);
-    if (fgets(cliptext, sizeof(cliptext)-1, fp) != NULL) {
-      data = Z_Malloc(sizeof(cliptext) + 1);
-      Q_strncpyz(data, cliptext, sizeof(cliptext));
+    cliptext = Z_Malloc(MAX_STRING_CHARS);
+    if (fgets(cliptext, sizeof(MAX_STRING_CHARS)-1, fp) != NULL) {
+      data = Z_Malloc(sizeof(MAX_STRING_CHARS) + 1);
+      Q_strncpyz(data, cliptext, sizeof(MAX_STRING_CHARS));
       strtok(data, "\n\r\b");
     }
     pclose(fp);


### PR DESCRIPTION
In its current form, pressing Ctrl-V will only paste a few characters (I found that it only pastes 6).

Commit 54c41536 introduces a bug where not enough memory is allocated for the clipboard text buffer, `cliptext`. `cliptext` is a malloc'ed string, so `sizeof` should not correctly report its size.
