### PR TITLE
Fixed dmaHD entering an infinite loop on certain maps

### DIFF
--- a/code/client/snd_dmahd.c
+++ b/code/client/snd_dmahd.c
@@ -285,6 +285,7 @@ static float dmaHD_InterpolateHermite4pt3oX(float x0, float x1, float x2, float 
     return (((((c3*t)+c2)*t)+c1)*t)+c0;
 }
 static float dmaHD_NormalizeSamplePosition(float t, int samples) {
+	if (!samples) return t;
 	while (t<0.0) t+=(float)samples; while (t>=(float)samples) t-=(float)samples; return t;
 }
 static int dmaHD_GetSampleRaw_8bit(int index, int samples, byte* data) 


### PR DESCRIPTION
In certain cases (sound/misc/windfly.wav in ut4_kingsgambit_a9.pk3, for example), dmaHD_NormalizeSamplePosition will get a "samples" value of 0, and it will enter an infinite loop. This is happening because the "data" chunk of a wav file has a size of 0. According to ioquake/ioq3@ae39051f, these are legal, so I didn't change the behaviour of the wav file loader.
