### PR TITLE
Use libcurl.so.4 by default rather than libcurl.so.3

### DIFF
--- a/code/client/cl_curl.h
+++ b/code/client/cl_curl.h
@@ -30,11 +30,11 @@ extern cvar_t *cl_cURLLib;
 #include "../qcommon/qcommon.h"
 
 #ifdef WIN32
-#define DEFAULT_CURL_LIB "libcurl-3.dll"
+#define DEFAULT_CURL_LIB "libcurl-4.dll"
 #elif defined(MACOS_X)
 #define DEFAULT_CURL_LIB "libcurl.dylib"
 #else
-#define DEFAULT_CURL_LIB "libcurl.so.3"
+#define DEFAULT_CURL_LIB "libcurl.so.4"
 #endif
 
 #if USE_LOCAL_HEADERS


### PR DESCRIPTION
By default, the engine tries to use `libcurl.so.3` which can fail on some linux distribs.

The .so.3 -> .so.4 transition came with curl 7.16.0, which was released in **2006**. Some distributions such as debian have kept a `libcurl.so.3` symlink to `libcurl.so.4` but some others like archlinux or fedora only have `libcurl.so.4`.

Therefore, I think this change makes sense and should not break anything.