### PR TITLE
Fixed a few compiler warnings

### DIFF
--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -582,8 +582,12 @@ static unsigned short yuv_to_rgb( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 8;
 	b = (YY + ROQ_UB_tab[u]) >> 9;
 	
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 31) r = 31; if (g > 63) g = 63; if (b > 31) b = 31;
+	if (r<0) r = 0;
+	if (g<0) g = 0;
+	if (b<0) b = 0;
+	if (r > 31) r = 31;
+	if (g > 63) g = 63;
+	if (b > 31) b = 31;
 
 	return (unsigned short)((r<<11)+(g<<5)+(b));
 }
@@ -603,8 +607,12 @@ static unsigned int yuv_to_rgb24( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 6;
 	b = (YY + ROQ_UB_tab[u]) >> 6;
 	
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	if (r<0) r = 0;
+	if (g<0) g = 0;
+	if (b<0) b = 0;
+	if (r > 255) r = 255;
+	if (g > 255) g = 255;
+	if (b > 255) b = 255;
 	
 	return LittleLong ((r)|(g<<8)|(b<<16)|(255<<24));
 }

--- a/code/client/cl_parse.c
+++ b/code/client/cl_parse.c
@@ -420,7 +420,7 @@ CL_ParseCompressedPureList
 Decode, decompress and set pure file list from compressed data
 ================
 */
-void CL_ParseCompressedPureList()
+void CL_ParseCompressedPureList(void)
 {
  int i,esc,sh,shc,bl;
  static unsigned char buf[PURE_COMPRESS_BUFFER];

--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -319,7 +319,7 @@ int	SCR_GetBigStringWidth( const char *str ) {
 
 int SCR_FontWidth(const char *text, float scale) {
 	if (!cls.fontFont)
-		return;
+		return 0;
 
 	int 		 count, len;
 	float		 out;

--- a/code/client/cl_ui.c
+++ b/code/client/cl_ui.c
@@ -1122,7 +1122,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return NET_StringToAdr( VMA(1), VMA(2));
 		
 	case UI_Q_VSNPRINTF:
-		return Q_vsnprintf( VMA(1), VMA(2), VMA(3), VMA(4));
+		return Q_vsnprintf( VMA(1), *((size_t *)VMA(2)), VMA(3), VMA(4));
 		
 	case UI_NET_SENDPACKET:
 		{
@@ -1135,7 +1135,8 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 		
 	case UI_COPYSTRING:
-		return CopyString(VMA(1));
+		CopyString(VMA(1));
+		return 0;
 
 	//case UI_SYS_STARTPROCESS:
 	//	Sys_StartProcess( VMA(1), VMA(2) );

--- a/code/client/snd_dmahd.c
+++ b/code/client/snd_dmahd.c
@@ -286,7 +286,9 @@ static float dmaHD_InterpolateHermite4pt3oX(float x0, float x1, float x2, float 
 }
 static float dmaHD_NormalizeSamplePosition(float t, int samples) {
 	if (!samples) return t;
-	while (t<0.0) t+=(float)samples; while (t>=(float)samples) t-=(float)samples; return t;
+	while (t<0.0) t+=(float)samples;
+	while (t>=(float)samples) t-=(float)samples;
+	return t;
 }
 static int dmaHD_GetSampleRaw_8bit(int index, int samples, byte* data) 
 {

--- a/code/qcommon/cvar.c
+++ b/code/qcommon/cvar.c
@@ -815,7 +815,7 @@ void Cvar_Restart_f( void ) {
 			}
 			// clear the var completely, since we
 			// can't remove the index from the list
-			Com_Memset( var, 0, sizeof( var ) );
+			Com_Memset( var, 0, sizeof( cvar_t ) );
 			continue;
 		}
 

--- a/code/qcommon/md5.c
+++ b/code/qcommon/md5.c
@@ -253,7 +253,7 @@ static void MD5Final(struct MD5Context *ctx, unsigned char *digest)
     
     if (digest!=NULL)
 	    memcpy(digest, ctx->buf, 16);
-    memset(ctx, 0, sizeof(ctx));	/* In case it's sensitive */
+    memset(ctx, 0, sizeof(struct MD5Context));	/* In case it's sensitive */
 }
 
 

--- a/code/qcommon/unzip.c
+++ b/code/qcommon/unzip.c
@@ -1412,8 +1412,8 @@ extern int unzClose (unzFile file)
 		return UNZ_PARAMERROR;
 	s=(unz_s*)file;
 
-    if (s->pfile_in_zip_read!=NULL)
-        unzCloseCurrentFile(file);
+	if (s->pfile_in_zip_read!=NULL)
+		unzCloseCurrentFile(file);
 
 	fclose(s->file);
 	TRYFREE(s);
@@ -1737,8 +1737,8 @@ extern int unzLocateFile (unzFile file, const char *szFileName, int iCaseSensiti
 	if (file==NULL)
 		return UNZ_PARAMERROR;
 
-    if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
-        return UNZ_PARAMERROR;
+	if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
+		return UNZ_PARAMERROR;
 
 	s=(unz_s*)file;
 	if (!s->current_file_ok)
@@ -1812,9 +1812,9 @@ static int unzlocal_CheckCurrentFileCoherencyHeader (unz_s* s, uInt* piSizeVar,
 	else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compression_method))
 		err=UNZ_BADZIPFILE;
 
-    if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
-                         (s->cur_file_info.compression_method!=Z_DEFLATED))
-        err=UNZ_BADZIPFILE;
+	if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
+		                 (s->cur_file_info.compression_method!=Z_DEFLATED))
+		err=UNZ_BADZIPFILE;
 
 	if (unzlocal_getLong(s->file,&uData) != UNZ_OK) /* date/time */
 		err=UNZ_ERRNO;
@@ -1876,8 +1876,8 @@ extern int unzOpenCurrentFile (unzFile file)
 	if (!s->current_file_ok)
 		return UNZ_PARAMERROR;
 
-    if (s->pfile_in_zip_read != NULL)
-        unzCloseCurrentFile(file);
+	if (s->pfile_in_zip_read != NULL)
+		unzCloseCurrentFile(file);
 
 	if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
 				&offset_local_extrafield,&size_local_extrafield)!=UNZ_OK)

--- a/code/qcommon/vm_x86_64_assembler.c
+++ b/code/qcommon/vm_x86_64_assembler.c
@@ -593,7 +593,7 @@ static void emit_mov(const char* mnemonic, arg_t arg1, arg_t arg2, void* data)
 				crap("value too large for 16bit register");
 			emit1(0x66);
 		}
-		else if(!arg2.v.reg & R_64)
+		else if(!(arg2.v.reg & R_64))
 		{
 			if(!isu32(arg1.v.imm))
 				crap("value too large for 32bit register");

--- a/code/renderer/tr_image.c
+++ b/code/renderer/tr_image.c
@@ -4164,7 +4164,7 @@ static void LoadPNG(const char *name, byte **pic, int *width, int *height)
         {
             case PNG_ColourType_Grey :
             {
-                if(!ChunkHeaderLength == 2)
+                if(ChunkHeaderLength != 2)
                 {
                     CloseBufferedFile(ThePNG);
   
@@ -4186,7 +4186,7 @@ static void LoadPNG(const char *name, byte **pic, int *width, int *height)
    
             case PNG_ColourType_True :
             {
-                if(!ChunkHeaderLength == 6)
+                if(ChunkHeaderLength != 6)
                 {
                     CloseBufferedFile(ThePNG);
   


### PR DESCRIPTION
Barbatos, after seeing you are fixing compiler warnings, here are a few more. These are only from compiling in Debian and not those related to unused variables. I have only tested them in Debian (only one play test in a 4.2 server, and one in a 4.3 server).