### PR TITLE
New mouse acceleration style 2, with logistic curve for smooth and  limited accel

### DIFF
--- a/README
+++ b/README
@@ -118,7 +118,8 @@ New cvars
   cl_aviFrameRate                   - the framerate to use when capturing video
   cl_aviMotionJpeg                  - use the mjpeg codec when capturing video
   cl_mouseAccelStyle                - Set to 1 for QuakeLive mouse acceleration
-                                      behaviour, 0 for standard q3
+                                      behaviour, 2 for UrbanTerror newest mode
+                                      or set to 0 for standard q3 mode.
   cl_mouseAccelOffset               - Tuning the acceleration curve, see below
 
   s_useOpenAL                       - use the OpenAL sound backend if available
@@ -241,6 +242,28 @@ QuakeLive mouse acceleration (patch and this text written by TTimo from id)
   If you try the new acceleration code and start using it, I'd be very
   interested by your feedback.
 
+UrbanTerror newest mouse acceleration mode, enabled by set cl_mouseAccelStyle 2
+  It uses the same 3 cvars as QuakeLive mouse acceleration (see above).
+  The difference is that the curve used is a logistic one, and it is applied
+  to change sensitivity by a factor depending on mouse movement rate (speed).
+  For low speeds the factor is almost 1 (i.e., no acceleration), and for highest
+  speeds the factor is (1+cl_mouseAccel), that is the maximum acceleration.
+  
+  cl_mouseAccelOffset fixes the point where the acceleration in the factor 
+  applied to sensitivity will be half the maximum:  (1+0.5*cl_mouseAccel).
+  
+  The result is a controllable smooth transition into mouse acceleration, and
+  that the maximum acceleration is naturally limited (by the logistic curve).
+
+  To configure it, try to set sensitivity to a value confortable for fine aim
+  moving the mouse slowly, taking note of how much angle is turned by moving
+  slowly only the hand (wrist) from side to side. Then set cl_mouseAccel to
+  a value (greater than 0) to expand that range (e.g., value 1 will double it) 
+  to obtain the maximum range reachable with a very fast wrist turn. 
+  Then, adjust the value of cl_mouseOffset to feel confortable with transition.
+  
+  Of course, the operating system mouse acceleration (or in hardware) must be 
+  dissabled to obtain controllable results with any in-game acceleration.
 
 64bit mods
   If you wish to compile external mods as shared libraries on a 64bit platform,

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -461,17 +461,32 @@ void CL_MouseMove(usercmd_t *cmd)
 			float power[2];
 
 			// sensitivity remains pretty much unchanged at low speeds
-			// cl_mouseAccel is a power value to how the acceleration is shaped
-			// cl_mouseAccelOffset is the rate for which the acceleration will have doubled the non accelerated amplification
 			// NOTE: decouple the config cvars for independent acceleration setup along X and Y?
-
 			rate[0] = fabs(mx) / (float) frame_msec;
 			rate[1] = fabs(my) / (float) frame_msec;
-			power[0] = powf(rate[0] / cl_mouseAccelOffset->value, cl_mouseAccel->value);
-			power[1] = powf(rate[1] / cl_mouseAccelOffset->value, cl_mouseAccel->value);
 
-			mx = cl_sensitivity->value * (mx + ((mx < 0) ? -power[0] : power[0]) * cl_mouseAccelOffset->value);
-			my = cl_sensitivity->value * (my + ((my < 0) ? -power[1] : power[1]) * cl_mouseAccelOffset->value);
+			if(cl_mouseAccelStyle->integer == 1)
+			{
+				// cl_mouseAccel is a power value to how the acceleration is shaped
+				// cl_mouseAccelOffset is the rate for which the acceleration will have doubled the non accelerated amplification
+
+				power[0] = powf(rate[0] / cl_mouseAccelOffset->value, cl_mouseAccel->value);
+				power[1] = powf(rate[1] / cl_mouseAccelOffset->value, cl_mouseAccel->value);
+
+				mx = cl_sensitivity->value * (mx + ((mx < 0) ? -power[0] : power[0]) * cl_mouseAccelOffset->value);
+				my = cl_sensitivity->value * (my + ((my < 0) ? -power[1] : power[1]) * cl_mouseAccelOffset->value);
+			}
+			else    // Newest style 2 with limited acceleration and smooth transition
+			{
+				// cl_mouseAccel is the maximum factor to add to base sensitivity
+				// cl_mouseOffset is the rate for which acceleration is half the max.
+
+				power[0] = 1.f / ( 1.f+expf(8.f*(1.f-rate[0]/cl_mouseAccelOffset->value)) );
+				power[1] = 1.f / ( 1.f+expf(8.f*(1.f-rate[1]/cl_mouseAccelOffset->value)) );
+
+				mx *= cl_sensitivity->value * (1.f + cl_mouseAccel->value * power[0]);
+				my *= cl_sensitivity->value * (1.f + cl_mouseAccel->value * power[1]);
+			}
 
 			if(cl_showMouseRate->integer)
 				Com_Printf("ratex: %f, ratey: %f, powx: %f, powy: %f\n", rate[0], rate[1], power[0], power[1]);

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -2915,10 +2915,11 @@ void CL_Init( void ) {
 
 	// 0: legacy mouse acceleration
 	// 1: new implementation
+	// 2: newest implementation (limited and smooth)
 	cl_mouseAccelStyle = Cvar_Get( "cl_mouseAccelStyle", "0", CVAR_ARCHIVE );
 
-	// offset for the power function (for style 1, ignored otherwise)
-	// this should be set to the max rate value
+	// for style 1: offset for the power function, should be set to the max rate value
+	// for style 2: rate for which acceleration is half of the maximum.
 	cl_mouseAccelOffset = Cvar_Get( "cl_mouseAccelOffset", "5", CVAR_ARCHIVE );
 
 	cl_showMouseRate = Cvar_Get ("cl_showmouserate", "0", 0);


### PR DESCRIPTION
The new mouse acceleration style 2 use the same cvars as the style 1 (from Quakelive) and the code preserves all the previous modes (style 0 and style 1 are not changed).
This acceleration mode is more easily configurable. The acceleration is limited and the transition between slow (no acceleration) and acceleration is smooth and controllable.
This mode could be useful with an old or cheap mouse to increase usable range.
