### PR TITLE
Minor changes to avoid some compilation warnings and two corrections.

### DIFF
--- a/code/client/cl_avi.c
+++ b/code/client/cl_avi.c
@@ -555,7 +555,7 @@ void CL_WriteAVIAudioFrame( const byte *pcmBuffer, int size )
 
     afd.numAudioFrames++;
     afd.moviSize += ( chunkSize + paddingSize );
-    afd.a.totalBytes =+ bytesInBuffer;
+    afd.a.totalBytes += bytesInBuffer;
 
     // Index
     bufIndex = 0;

--- a/code/sys/con_tty.c
+++ b/code/sys/con_tty.c
@@ -281,8 +281,7 @@ void CON_Init( void )
 	characters  EOF,  EOL,  EOL2, ERASE, KILL, REPRINT,
 	STATUS, and WERASE, and buffers by lines.
 	ISIG: when any of the characters  INTR,  QUIT,  SUSP,  or
-	DSUSP are received, generate the corresponding sig­
-	nal
+	DSUSP are received, generate the corresponding signal
 	*/
 	tc.c_lflag &= ~(ECHO | ICANON);
 

--- a/code/unix/sdl_glimp.c
+++ b/code/unix/sdl_glimp.c
@@ -427,7 +427,8 @@ static void HandleEvents(void)
     case SDL_MOUSEMOTION:
       if (mouse_active)
       {
-        Sys_QueEvent( t, SE_MOUSE, e.motion.xrel, e.motion.yrel, 0, NULL );
+        if (e.motion.xrel != 0 || e.motion.yrel != 0)
+            Sys_QueEvent( t, SE_MOUSE, e.motion.xrel, e.motion.yrel, 0, NULL );
       }
       break;
 

--- a/code/unix/unix_main.c
+++ b/code/unix/unix_main.c
@@ -528,8 +528,7 @@ void Sys_ConsoleInputInit( void )
               characters  EOF,  EOL,  EOL2, ERASE, KILL, REPRINT,
               STATUS, and WERASE, and buffers by lines.
      ISIG: when any of the characters  INTR,  QUIT,  SUSP,  or
-              DSUSP are received, generate the corresponding sig­
-              nal
+              DSUSP are received, generate the corresponding signal
     */              
     tc.c_lflag &= ~(ECHO | ICANON);
     /*


### PR DESCRIPTION
The minor changes are:
* Correction of an intended increment operator wrongly typed in video encoder.
* Remove unnecessary intermediate pointer (producing array limits warnings in gcc 6) in wavelet sound decoder by a simpler but equivalent code.
* Prevent excess of null mouse motion events from fractional changes truncated
 to integer in SDL1.2.
* Remove two non-ascii softhyphen characters in comments producing warnings in gcc 6.