### PR TITLE
Freebsd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ ifeq ($(PLATFORM),freebsd)
    endif
 
   # flags
-  BASE_CFLAGS = $(shell env MACHINE_ARCH=$(ARCH) make -f /dev/null -VCFLAGS) \
+  BASE_CFLAGS = \
     -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
     -DHOMEPATH=\\\"$(HOMEPATH)\\\" \
     -DDEFAULT_LIBDIR=\\\"$(DEFAULT_LIBDIR)\\\" \

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ ifeq ($(PLATFORM),freebsd)
   CLIENT_CFLAGS += $(SDL_CFLAGS)
   HAVE_VM_COMPILED = true
 
-  OPTIMIZEVM = -O3 -funroll-loops -fomit-frame-pointer
+  OPTIMIZEVM =
   OPTIMIZE = $(OPTIMIZEVM) -ffast-math
 
   SHLIBEXT=so


### PR DESCRIPTION
Update FreeBSD build section to match commonly expected behaviour:

- Use CFLAGS -On level (-O3 binaries are usually slower than -O2 any way)
- Don't pull CFLAGS into BASE_CFLAGS